### PR TITLE
Added Spritz-Wine-AAGL-TkG 10.6-1

### DIFF
--- a/components.json
+++ b/components.json
@@ -9,6 +9,10 @@
             "title": "Wine-GE-Proton"
         },
         {
+            "name": "spritz-wine-tkg",
+            "title": "Spritz-Wine-TkG"
+        },
+        {
             "name": "caffe",
             "title": "Caffe"
         },

--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "spritz-wine-aagl-tkg-10.6",
+        "title": "Spritz-Wine-AAGL-TkG 10.6-1",
+        "uri": "https://github.com/NelloKudo/WineBuilder/releases/download/aagl-spritz-v10.6-1/spritz-wine-aagl-tkg-fonts-wow64-10.6-1-x86_64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine64",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    }
+]


### PR DESCRIPTION
Keep in sync with the main components repo: plain wine-tkg + GI patches.