### PR TITLE
Added Spritz-Wine-TkG 10.9!

### DIFF
--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,7 +1,18 @@
 [
     {
+        "name": "wine-spritz-10.9-staging-tkg-aagl-amd64-wow64",
+        "title": "Spritz-Wine-TkG 10.9-1",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.9-1/wine-spritz-10.9-staging-tkg-aagl-amd64-wow64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
+    {
         "name": "wine-spritz-10.6-staging-tkg-aagl-amd64-wow64",
-        "title": "Spritz-Wine-AAGL-TkG 10.6-1",
+        "title": "Spritz-Wine-TkG 10.6-1",
         "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.6-1/wine-spritz-10.6-staging-tkg-aagl-amd64-wow64.tar.xz",
         "files": {
             "wine": "bin/wine",


### PR DESCRIPTION
- Added a new patch fixing community/feedback tabs crashing
- Rebased to Wine-Staging-TkG 10.9
- Renamed to a shorter "title" for versions to look fine in the launcher