### PR TITLE
Added Spritz-Wine-TkG 10.10-1 and Spritz-Wine-TkG-NTsync 10.10-1

### DIFF
--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,4 +1,26 @@
-[
+[   
+    {
+        "name": "wine-spritz-10.10-1-staging-tkg-ntsync-aagl-amd64-wow64",
+        "title": "Spritz-Wine-TkG-NTsync 10.10-1",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-1/wine-spritz-10.10-1-staging-tkg-ntsync-aagl-amd64-wow64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        } 
+    },
+    {
+        "name": "wine-spritz-10.10-1-staging-tkg-aagl-amd64-wow64",
+        "title": "Spritz-Wine-TkG 10.10-1",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-1/wine-spritz-10.10-1-staging-tkg-aagl-amd64-wow64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
     {
         "name": "wine-spritz-10.9-staging-tkg-aagl-amd64-wow64",
         "title": "Spritz-Wine-TkG 10.9-1",


### PR DESCRIPTION
Changelogs:
- Added GI's CN version to the workarounds
- Added ZZZ to the internet workaround patch (seems to fix high CPU usage)
- Added an ntsync build

Patchset: https://github.com/NelloKudo/WineSpritz/tree/aagl-spritz-v10.10-1