### PR TITLE
Added Spritz Wine 10.10-2 (and NTsync), also 10.0-1 and set Spritz to…

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,20 +1,20 @@
 {
     "wine": [
         {
-            "name": "wine-staging-tkg",
-            "title": "Wine-Staging-TkG"
-        },
-        {
-            "name": "wine-ge-proton",
-            "title": "Wine-GE-Proton"
-        },
-        {
             "name": "spritz-wine-tkg",
             "title": "Spritz-Wine-TkG"
         },
         {
+            "name": "wine-staging-tkg",
+            "title": "Wine-Staging-TkG"
+        },
+        {
             "name": "spritz-wine-tkg-ntsync",
             "title": "Spritz-Wine-TkG-NTsync"
+        },
+        {
+            "name": "wine-ge-proton",
+            "title": "Wine-GE-Proton"
         },
         {
             "name": "caffe",

--- a/wine/spritz-wine-tkg-ntsync.json
+++ b/wine/spritz-wine-tkg-ntsync.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "wine-spritz-10.10-2-staging-tkg-ntsync-aagl-amd64",
+        "title": "Spritz-Wine-TkG-NTsync 10.10-2",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-2/wine-spritz-10.10-2-staging-tkg-ntsync-aagl-amd64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
+    {
         "name": "wine-spritz-10.10-1-staging-tkg-ntsync-aagl-amd64-wow64",
         "title": "Spritz-Wine-TkG-NTsync 10.10-1",
         "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-1/wine-spritz-10.10-1-staging-tkg-ntsync-aagl-amd64-wow64.tar.xz",
@@ -8,6 +19,9 @@
             "wine64": "bin/wine",
             "wineserver": "bin/wineserver",
             "wineboot": "bin/wineboot"
+        },
+        "features": {
+            "recommended": false
         }
     }
 ]

--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "wine-spritz-10.10-2-staging-tkg-aagl-amd64",
+        "title": "Spritz-Wine-TkG 10.10-2",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-2/wine-spritz-10.10-2-staging-tkg-aagl-amd64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
+    {
         "name": "wine-spritz-10.10-1-staging-tkg-aagl-amd64-wow64",
         "title": "Spritz-Wine-TkG 10.10-1",
         "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-1/wine-spritz-10.10-1-staging-tkg-aagl-amd64-wow64.tar.xz",
@@ -8,6 +19,9 @@
             "wine64": "bin/wine",
             "wineserver": "bin/wineserver",
             "wineboot": "bin/wineboot"
+        },
+        "features": {
+            "recommended": false
         }
     },
     {
@@ -19,6 +33,9 @@
             "wine64": "bin/wine",
             "wineserver": "bin/wineserver",
             "wineboot": "bin/wineboot"
+        },
+        "features": {
+            "recommended": false
         }
     },
     {
@@ -28,6 +45,20 @@
         "files": {
             "wine": "bin/wine",
             "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        },
+        "features": {
+            "recommended": false
+        }
+    },
+    {
+        "name": "wine-spritz-10.0-1-staging-tkg-aagl-amd64",
+        "title": "Spritz-Wine-TkG 10.0-1",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.0-1/wine-spritz-10.0-1-staging-tkg-aagl-amd64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine64",
             "wineserver": "bin/wineserver",
             "wineboot": "bin/wineboot"
         }


### PR DESCRIPTION
… default

- Added 10.10-2 and 10.0-1, with new patches fixing HSR/HI3 cutscenes and issues with prefixes on Flatpak
- Labeled old builds (WoW64) as not recommended to avoid having issues on Flatpak
- Set Spritz-Wine-TkG 10.10-2 as default build