### PR TITLE
Added Spritz-Wine-TkG-NTsync 10.10-3

### DIFF
--- a/wine/spritz-wine-tkg-ntsync.json
+++ b/wine/spritz-wine-tkg-ntsync.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "wine-spritz-10.10-3-staging-tkg-ntsync-aagl-amd64",
+        "title": "Spritz-Wine-TkG-NTsync 10.10-3",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-3/wine-spritz-10.10-3-staging-tkg-ntsync-aagl-amd64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
+    {
         "name": "wine-spritz-10.10-2-staging-tkg-ntsync-aagl-amd64",
         "title": "Spritz-Wine-TkG-NTsync 10.10-2",
         "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-2/wine-spritz-10.10-2-staging-tkg-ntsync-aagl-amd64.tar.xz",
@@ -8,6 +19,9 @@
             "wine64": "bin/wine",
             "wineserver": "bin/wineserver",
             "wineboot": "bin/wineboot"
+        },
+        "features": {
+            "recommended": false
         }
     },
     {


### PR DESCRIPTION
- Fixes NTsync build not launching on Flatpak
- Mark 10.10-2 as not recommended