### PR TITLE
Added Spritz-Wine-TkG (and NTsync) 10.12-1

### DIFF
--- a/wine/spritz-wine-tkg-ntsync.json
+++ b/wine/spritz-wine-tkg-ntsync.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "wine-spritz-10.12-1-staging-tkg-ntsync-aagl-amd64-wow64",
+        "title": "Spritz-Wine-TkG-NTsync 10.12-1",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.12-1/wine-spritz-10.12-1-staging-tkg-ntsync-aagl-amd64-wow64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
+    {
         "name": "wine-spritz-10.10-3-staging-tkg-ntsync-aagl-amd64",
         "title": "Spritz-Wine-TkG-NTsync 10.10-3",
         "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-3/wine-spritz-10.10-3-staging-tkg-ntsync-aagl-amd64.tar.xz",

--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "wine-spritz-10.12-1-staging-tkg-aagl-amd64-wow64",
+        "title": "Spritz-Wine-TkG 10.12-1",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.12-1/wine-spritz-10.12-1-staging-tkg-aagl-amd64-wow64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    },
+    {
         "name": "wine-spritz-10.10-2-staging-tkg-aagl-amd64",
         "title": "Spritz-Wine-TkG 10.10-2",
         "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.10-2/wine-spritz-10.10-2-staging-tkg-aagl-amd64.tar.xz",


### PR DESCRIPTION
- Update to Wine/Staging 10.12
- Added winex11 patch fixing Unity games losing input after alt-tab (GI,HSR etc.)
- Removed gstreamer patch (now upstream!)
- Removed AAGL wineloader workarounds (fixed by build script refactor)